### PR TITLE
Optimise ast parsing

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -19,7 +19,7 @@ E.g. Right now this happens, and...
 A clear and concise description of what you think would be better
 
 
-### Notes
+## Notes
 
 Any alternative solutions or ideas you've considered
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.10.2
+
+- Optimise AST parsing [#14](../../issues/14)
+
 ## v0.10.1
 
 - Respect ignored files and folders [#12](../../issues/12)

--- a/README.md
+++ b/README.md
@@ -237,9 +237,9 @@ If you want to see what the module does as it runs, set `debug` to true:
 
 When Nuxt builds, the module scans all content sources for assets, copies them to an accessible public assets folder, and indexes path and image metadata.
 
-After Nuxt Content has run the parsed content is traversed, and both element attributes and frontmatter properties are checked to see if they resolve to the indexed asset paths.
+After Nuxt Content has run, the parsed content is traversed, and both element attributes and frontmatter properties are checked to see if they resolve to the indexed asset paths.
 
-If they do, then the attribute or property is rewritten with the absolute path. If the asset is an image, then the element or path is optionally updated with size attributes or size query string.
+If they do, then the attribute or property is rewritten with the absolute path. If the asset is an image, then the element or metadata is optionally updated with size attributes or a query string.
 
 Finally, Nitro serves the site, and any requests made to the transformed asset paths should be picked up and the *copied* asset served by the browser.
 

--- a/demo/components/content/ContentGallery.vue
+++ b/demo/components/content/ContentGallery.vue
@@ -3,7 +3,7 @@
     <div class="columns is-multiline">
       <div v-for="item in data" :key="item.src" class="column is-half">
         <NuxtLink :to="item.route">
-          <ContentImage :src="item.image" :title="item.title" />
+          <ContentImage :image="item.image" :title="item.title" />
         </NuxtLink>
         <p>{{ item.title }}</p>
       </div>

--- a/demo/content/advanced/component/index.md
+++ b/demo/content/advanced/component/index.md
@@ -2,7 +2,7 @@
 
 > Custom image component 
 
-:content-image{src="../frontmatter/turkey-casserole.jpg" alt="Turkey & Pesto Casserole"}
+:content-image{image="../frontmatter/turkey-casserole.jpg" alt="Turkey & Pesto Casserole"}
 
 Free-range British turkey coated in velvety coconut yoghurt and fragrant red pesto. Served over a bed of fibre-packed brown rice, studded with vitamin K-source spinach. An easy and comforting midweek meal for those busy days.
 

--- a/demo/content/assets/index.md
+++ b/demo/content/assets/index.md
@@ -25,3 +25,4 @@ Framed content displays directly:
 Display PDFs or other embeddable content:
 
 <embed src="media/sample.pdf" width="100%" height="500"></embed>
+

--- a/demo/content/internal/traversal.md
+++ b/demo/content/internal/traversal.md
@@ -1,0 +1,19 @@
+# Code
+
+> Path replacement skips invalid elements
+
+Code should be skipped:
+
+```js
+function getAsset(srcDoc, relAsset) {
+  const srcAsset = Path.join(Path.dirname(srcDoc), relAsset);
+  return assets[srcAsset] || {};
+}
+```
+
+Tables should be processed:
+
+| Label                        | Image                                                                      |
+|------------------------------|-----------------------------------------------------------------------------|
+| This is a load of dummy text | :img{src="../advanced/frontmatter/turkey-casserole.jpg" style="width: 50%"} |
+

--- a/demo/content/main.md
+++ b/demo/content/main.md
@@ -12,6 +12,10 @@ Paths:
 - [Image in sub folder](paths/pesto-salmon-lentils)
 - [Image in parent folder](paths/sicilian-fish-stew)
 
+Assets:
+
+- [Media and file assets](assets)
+
 Advanced:
 
 - [Image `src` from `frontmatter` variable](advanced/frontmatter)
@@ -22,9 +26,9 @@ Sources:
 
 - [Content from GitHub](external) (disabled in StackBlitz)
 
-Assets:
+Internal:
 
-- [Media and file assets](assets)
+- [Path replacement skips invalid elements](internal/traversal)
 
 GitHub:
 

--- a/demo/content/paths/pesto-salmon-lentils/index.md
+++ b/demo/content/paths/pesto-salmon-lentils/index.md
@@ -30,7 +30,6 @@ Slathered in peppery basil pesto, sprinkled with pine nuts and baked until irres
 
 ## Instructions
 
-
 Preheat the oven to 200C / fan 180C / gas mark 6. 
 
 Thinly slice the courgette into half-moons. Cut the pepper into 3-4cm squares. 

--- a/demo/nuxt.config.ts
+++ b/demo/nuxt.config.ts
@@ -35,6 +35,7 @@ export default defineNuxtConfig({
   // https://content.nuxtjs.org/api/configuration
   content: {
     sources,
+    highlight: true,
     markdown: {
       anchorLinks: false,
     },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nuxt-content-assets",
-  "version": "0.10.1",
+  "version": "0.10.2",
   "description": "Enable locally-located assets in Nuxt Content",
   "repository": "davestewart/nuxt-content-assets",
   "license": "MIT",

--- a/src/module.ts
+++ b/src/module.ts
@@ -214,8 +214,10 @@ export default defineNuxtModule<ModuleOptions>({
     // ---------------------------------------------------------------------------------------------------------------------
 
     // build config
+    const makeVar = (name: string, value: any) => `export const ${name} = ${JSON.stringify(value)};`
     const virtualConfig = [
-      `export const cachePath = '${cachePath}'`,
+      makeVar('cachePath', cachePath),
+      makeVar('debug', options.debug),
     ].join('\n')
 
     // setup server plugin

--- a/src/runtime/services/sources.ts
+++ b/src/runtime/services/sources.ts
@@ -3,7 +3,26 @@ import { createStorage, WatchEvent, Storage } from 'unstorage'
 import githubDriver, { GithubOptions } from 'unstorage/drivers/github'
 import fsDriver, { FSStorageOptions } from 'unstorage/drivers/fs'
 import { MountOptions } from '@nuxt/content'
-import { warn, isAsset, toPath, removeFile, copyFile, writeBlob, writeFile, deKey } from '../utils'
+import {
+  warn,
+  isAsset,
+  toPath,
+  removeFile,
+  copyFile,
+  writeBlob,
+  writeFile,
+  deKey,
+  isExcluded,
+} from '../utils'
+
+/**
+ * Helper function to determine valid ids
+ * @param id
+ */
+function isAssetId (id: string) {
+  const path = toPath(id)
+  return !isExcluded(path) && isAsset(path)
+}
 
 /**
  * Make a Storage instance
@@ -54,7 +73,7 @@ export interface SourceManager {
 export function makeSourceManager (key: string, source: MountOptions, publicPath: string, callback?: (event: WatchEvent, path: string) => void): SourceManager {
   // only fs will trigger watch events
   async function onWatch (event: WatchEvent, key: string) {
-    if (isAsset(toPath(key))) {
+    if (isAssetId(key)) {
       const path = event === 'update'
         ? await copyItem(key)
         : removeItem(key)
@@ -137,9 +156,7 @@ export function makeSourceManager (key: string, source: MountOptions, publicPath
    */
   async function getKeys () {
     const keys = await storage.getKeys()
-    return keys
-      .map(toPath)
-      .filter(isAsset)
+    return keys.filter(isAssetId)
   }
 
   /**

--- a/src/runtime/utils/assert.ts
+++ b/src/runtime/utils/assert.ts
@@ -35,7 +35,7 @@ export function isArticle (path: string): boolean {
  * Test path is asset
  */
 export function isAsset (path: string): boolean {
-  return !isExcluded(path) && !isArticle(path)
+  return !isArticle(path)
 }
 
 /**

--- a/src/runtime/utils/debug.ts
+++ b/src/runtime/utils/debug.ts
@@ -1,11 +1,11 @@
-import { moduleKey } from '../config'
+const label = '[content-assets]'
 
 export function log (...data: any[]): void {
-  console.info(`[${moduleKey}]`, ...data)
+  console.info(label, ...data)
 }
 
 export function warn (...data: any[]): void {
-  console.warn(`[${moduleKey}]`, ...data)
+  console.warn(label, ...data)
 }
 
 export function list(message: string, items: string[]) {

--- a/src/runtime/utils/string.ts
+++ b/src/runtime/utils/string.ts
@@ -3,17 +3,26 @@
  *
  * Tokens may be separated by space, comma or pipe
  */
-export function matchTokens (value?: string | unknown[]): string[] {
-  const tokens = typeof value === 'string'
-    ? value.match(/[^\s,|]+/g) || []
-    : Array.isArray(value)
-      ? value
-        .filter(value => typeof value === 'string')
-        .reduce((output, input) => {
-          return [ ...output, ...matchTokens(input)]
-        }, [])
-      : []
-  return Array.from(new Set(tokens))
+export function matchTokens (value: any): string[] {
+  let tokens: string[] = []
+  if (typeof value === 'string') {
+    tokens = value.match(/[^\s,|]+/g) || []
+  }
+  else if (Array.isArray(value)) {
+    tokens = value
+      .filter(value => typeof value === 'string')
+      .reduce((output: string[], input) => {
+        return [ ...output, ...matchTokens(input)]
+      }, [])
+  }
+  else if (!!value && typeof value === 'object') {
+    tokens = Object.values(value).reduce((output: string[], value) => {
+      return [...output, ...matchTokens(value)]
+    }, [])
+  }
+  return tokens.length
+    ? Array.from(new Set(tokens))
+    : tokens
 }
 
 export function toPath (key: string): string {


### PR DESCRIPTION
With the introduction of processing every AST node, it became apparent that invalid nodes were being considered for path rewriting.

This PR fixes that by skipping content of invalid containers, and skipping attributes of known non-asset nodes.

Closes #14 