### PR TITLE
Update the link to Nuxt Image

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,7 +205,7 @@ See demo component [here](demo/components/content/ContentImage.vue).
 
 ### Nuxt Image compatibility
 
-Nuxt Content Assets works with [Nuxt Image](https://v1.image.nuxtjs.org/) with just a little configuration.
+Nuxt Content Assets works with [Nuxt Image](https://image.nuxtjs.org/) with just a little configuration.
 
 First, configure Nuxt Image to use Nuxt Content Asset's public folder:
 


### PR DESCRIPTION
Nuxt Image v1 (the Nuxt 3-compatible version) is now using the default
domain, the "v1." subdomain doesn't exist any more. Fix the link in the
documentation.
