### PR TITLE
Update .stackblitzrc

### DIFF
--- a/.stackblitzrc
+++ b/.stackblitzrc
@@ -1,3 +1,3 @@
 {
-  "startCommand": "npm install && npm install --prefix ./demo && npm run dev"
+  "startCommand": "npm install --prefix ./demo && npm run dev"
 }


### PR DESCRIPTION
Removed first `npm install` since stackblitz prepends it to the startcommand causing it to run npm install twice in  the root folder