### PR TITLE
extended the npm install command for local setup in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ To clone and run the demo locally:
 ```bash
 git clone https://github.com/davestewart/nuxt-content-assets.git
 cd nuxt-content-assets
-npm install
+npm install && npm install --prefix ./demo
 npm run dev
 ```
 


### PR DESCRIPTION
Added a required step for the project to run in the setup instructions of running the demo locally.

suggested by https://github.com/davestewart/nuxt-content-assets/issues/44#issuecomment-1731748123