### PR TITLE
fix: import nuxt composables from #imports

### DIFF
--- a/demo/components/SiteNav.vue
+++ b/demo/components/SiteNav.vue
@@ -18,7 +18,7 @@
 </template>
 
 <script lang="ts">
-import { defineNuxtComponent } from '#app'
+import { defineNuxtComponent } from '#imports'
 
 function link (href: string, text: string) {
   return { href, text }


### PR DESCRIPTION
This is a DX improvement when developing - we can avoid loading the entire barrel file at `#app` by using the new granular imports merged in https://github.com/nuxt/nuxt/pull/23951.