### PR TITLE
chore: update to latest `@nuxt/module-builder`

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,17 +21,14 @@
   "scripts": {
     "dev:setup": "cpy cache playground/node_modules/nuxt-content-assets && cpy \"cache/**\" playground/.nuxt/content-assets",
     "dev:prepare": "nuxt-module-build build --stub && nuxt-module-build prepare",
-
     "dev": "nuxi dev playground",
     "dev:generate": "nuxi generate playground",
     "dev:build": "nuxi build playground",
     "dev:preview": "nuxi preview playground",
-
     "build": "nuxt-module-build build",
     "release:setup": "npm run lint && npm run test && npm run build",
     "release:dry": "npm run release:setup && npm publish --dry-run",
     "release": "npm run release:setup && npm publish",
-
     "lint": "eslint .",
     "test": "vitest run",
     "test:watch": "vitest watch"
@@ -53,7 +50,7 @@
   "devDependencies": {
     "@nuxt/devtools": "latest",
     "@nuxt/eslint-config": "^0.2.0",
-    "@nuxt/module-builder": "^0.5.5",
+    "@nuxt/module-builder": "^0.8.3",
     "@nuxt/schema": "^3.11.2",
     "@nuxt/test-utils": "^3.12.0",
     "@types/debounce": "^1.2.1",

--- a/package.json
+++ b/package.json
@@ -21,14 +21,17 @@
   "scripts": {
     "dev:setup": "cpy cache playground/node_modules/nuxt-content-assets && cpy \"cache/**\" playground/.nuxt/content-assets",
     "dev:prepare": "nuxt-module-build build --stub && nuxt-module-build prepare",
+
     "dev": "nuxi dev playground",
     "dev:generate": "nuxi generate playground",
     "dev:build": "nuxi build playground",
     "dev:preview": "nuxi preview playground",
+
     "build": "nuxt-module-build build",
     "release:setup": "npm run lint && npm run test && npm run build",
     "release:dry": "npm run release:setup && npm publish --dry-run",
     "release": "npm run release:setup && npm publish",
+
     "lint": "eslint .",
     "test": "vitest run",
     "test:watch": "vitest watch"


### PR DESCRIPTION
Previous versions of `@nuxt/module-builder` produced incorrect types for files in the `runtime/` directory. Specifically, a `.d.ts` declaration paired with a `.mjs` file. This isn't correct - it should be either `.d.mts`  and `.mjs` or `.d.ts` and `.js`. 

For maximum compatibility, `@nuxt/module-builder` v0.8 switched to `.js` extension for files in `runtime/` directory.

With the latest Nuxt, this is now an error that removes correct plugin injection types.

Related PRs: https://github.com/nuxt/nuxt/pull/28480, https://github.com/nuxt/nuxt/pull/28593
See also https://github.com/nuxt/nuxt/issues/28672.