### PR TITLE
Support avif, bmp and cur image formats

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### v1.6.0
+
+- Support `avif`, `bmp` and `cur` image formats
+
 ### v1.5.2
 
 - Nuxt 4 compatibility

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nuxt-content-assets",
-  "version": "1.5.2",
+  "version": "1.6.0",
   "description": "Enable locally-located assets in Nuxt Content",
   "repository": {
     "type": "git",

--- a/src/runtime/utils/config.ts
+++ b/src/runtime/utils/config.ts
@@ -4,11 +4,11 @@ import { matchTokens } from './string'
  * Common extensions
  */
 export const extensions = {
-  // used to get image size
-  image: matchTokens('png jpg jpeg gif svg webp ico'),
-
   // used to recognise content
   content: matchTokens('md mdx json yml yaml csv'),
+
+  // used to get image size
+  image: matchTokens('png jpg jpeg gif svg webp ico avif bmp cur'),
 
   // unused for now
   media: matchTokens('mp3 m4a wav mp4 mov webm ogg avi flv avchd'),


### PR DESCRIPTION
Closes #83

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds support for additional image formats and bumps the package version.
> 
> - Extends `extensions.image` in `src/runtime/utils/config.ts` to include `avif`, `bmp`, and `cur` for image size detection
> - Updates `CHANGELOG.md` with v1.6.0 entry
> - Bumps `package.json` version to `1.6.0`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fad519487365410a05c5acfc7f6c3996dd619bc1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->