### PR TITLE
Add support for image path query strings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
+### v1.7.0
+
+- Add support for image path query strings [#41](../../issues/41)
+
 ### v1.6.0
 
-- Support `avif`, `bmp` and `cur` image formats
+- Support `avif`, `bmp` and `cur` image formats [#83](../../issues/83)
 
 ### v1.5.2
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "nuxt-content-assets",
-  "version": "1.5.1",
+  "version": "1.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "nuxt-content-assets",
-      "version": "1.5.1",
+      "version": "1.6.0",
       "license": "MIT",
       "dependencies": {
         "@nuxt/kit": "^3.20.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nuxt-content-assets",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "description": "Enable locally-located assets in Nuxt Content",
   "repository": {
     "type": "git",

--- a/playground/content/advanced/query/index.md
+++ b/playground/content/advanced/query/index.md
@@ -1,0 +1,19 @@
+# Creamy Turkey & Sundried Tomato Pesto Casserole
+
+> Image with query string 
+
+This image has a query string (won't show in editors, not compatible with Nuxt Image):
+
+![image](../frontmatter/turkey-casserole.jpg?size=100)
+
+```
+../frontmatter/turkey-casserole.jpg?size=100
+```
+
+This image has no query:
+
+![image](../frontmatter/turkey-casserole.jpg)
+
+```
+../frontmatter/turkey-casserole.jpg
+```

--- a/playground/content/main.md
+++ b/playground/content/main.md
@@ -23,6 +23,7 @@ Advanced:
 - [Image `src` from `frontmatter` variable](advanced/frontmatter)
 - [Custom gallery component using `frontmatter` data](advanced/gallery)
 - [Custom image component](advanced/component)
+- [Query string support](advanced/query)
 
 Sources:
 


### PR DESCRIPTION
Closes #41 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds query-string support for image asset paths and updates docs/demo.
> 
> - Update `resolveAsset` in `src/runtime/assets/public.ts` to ignore query strings for lookup (`removeQuery`) and preserve them in returned `srcAttr` when present; now returns full `AssetConfig` with a safe empty fallback
> - Add playground demo `advanced/query/index.md` and link from `playground/content/main.md`
> - Bump version to `1.7.0` and update `CHANGELOG.md`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 332f32719154b4f13be3da12af5c14ebdf6a6ec0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->