### PR TITLE
Migrate docs to Vue 3 and add transformers examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,7 +215,7 @@ See playground component [here](playground/components/content/ContentImage.vue).
 
 ### Nuxt Image
 
-[Nuxt Image](https://image.nuxtjs.org/) is supported by adding Nuxt Content Asset's cache folder as a Nuxt Layer:
+To support [Nuxt Image](https://image.nuxtjs.org/), add Nuxt Content Asset's cache folder as a Nuxt Layer:
 
 ```ts
 // nuxt.config.ts
@@ -291,7 +291,7 @@ img {
 ### Content extensions
 
 > [!NOTE]
-> Generally, you shouldn't need to touch this setting
+> Generally, you shouldn't need to touch this setting, however, if you're looking to support custom content types [by way of transformers](https://v2.content.nuxt.com/recipes/transformers) then you'll need to add those extensions here.
 
 This setting tells Nuxt Content to ignore anything that is **not** one of the supported content types:
 

--- a/playground/app/app.vue
+++ b/playground/app/app.vue
@@ -3,13 +3,9 @@
     <NuxtLoadingIndicator :height="10" />
     <SiteNav />
     <div class="content">
-      <ContentDoc
-        :key="$route.path"
-        :path="$route.path === '/' ? '/main' : $route.path"
-      />
+      <NuxtPage />
     </div>
   </div>
-  <NuxtPage />
 </template>
 
 <style>

--- a/playground/app/components/SiteNav.vue
+++ b/playground/app/components/SiteNav.vue
@@ -17,30 +17,27 @@
   </nav>
 </template>
 
-<script lang="ts">
-import { defineNuxtComponent } from '#imports'
+<script setup lang="ts">
+import { computed, useRoute } from '#imports'
 
-function link (href: string, text: string) {
-  return { href, text }
+type Link = {
+  href: string
+  text: string
 }
 
-export default defineNuxtComponent({
-  computed: {
-    links () {
-      const links = [
-        link('/', 'Home'),
-      ]
-      const path = this.$route.path
-      const segments = path.replace(/\/$/, '').split('/')
-      if (path !== '/') {
-        links.push({
-          href: path,
-          text: segments[segments.length - 1].replace(/\W/g, ' ')
-        })
-      }
-      return links
-    }
+const links = computed<Link[]>(() => {
+  const links = [
+    { href: '/', text: 'Home' },
+  ]
+  const path = useRoute().path
+  const segments = path.replace(/\/$/, '').split('/')
+  if (path !== '/') {
+    links.push({
+      href: path,
+      text: segments[segments.length - 1].replace(/\W/g, ' ')
+    })
   }
+  return links
 })
 </script>
 

--- a/playground/app/components/content/ContentGallery.vue
+++ b/playground/app/components/content/ContentGallery.vue
@@ -1,27 +1,21 @@
 <template>
   <div class="gallery">
     <div class="columns is-multiline">
-      <div v-for="item in data" :key="item.src" class="column is-half">
-        <ContentImage :src="item.image" :title="item.title" />
+      <div v-for="item in items" :key="item.image" class="column is-half">
+        <ContentImage :image="item.image" :title="item.title" />
         <p>{{ item.title }}</p>
       </div>
     </div>
   </div>
 </template>
 
-<script lang="ts">
+<script setup lang="ts">
 import ContentImage from './ContentImage.vue'
 
-export default {
-  components: {
-    ContentImage,
-  },
-
-  props: {
-    data: {
-      type: Array,
-      required: true,
-    }
-  },
-}
+defineProps<{
+  items: Array<{
+    image: string
+    title: string
+  }>
+}>()
 </script>

--- a/playground/app/components/content/ContentImage.vue
+++ b/playground/app/components/content/ContentImage.vue
@@ -4,42 +4,35 @@
     :src="info.src"
     :width="info.width"
     :height="info.height"
-    :alt="title"
+    :alt="title ?? ''"
   >
 </template>
 
-<script>
-export default {
-  global: true,
+<script lang="ts" setup>
+import { computed } from '#imports'
 
-  props: {
-    image: {
-      type: String,
-      required: true,
-    },
-    title: {
-      type: String,
-      default: '',
-    },
-  },
+const props = defineProps<{
+  image: string
+  title?: string
+}>()
 
-  computed: {
-    info () {
-      return parseImageInfo(this.image)
-    },
-  }
-}
-
-/**
- * Parse src, width and height from URL
- */
-function parseImageInfo (url = '') {
-  const [src, query] = url.split('?')
+const info = computed(() => {
+  const [src, query] = props.image.split('?')
   const params = new URLSearchParams(query)
   return {
     src,
     width: Number(params.get('width')) || undefined,
     height: Number(params.get('height')) || undefined,
   }
-}
+})
 </script>
+
+<style>
+.content-image {
+  display: block;
+  margin: 1rem auto;
+  max-width: 100%;
+  border-radius: 2%;
+  box-shadow: 0 10px 18px rgba(0, 0, 0, 0.3);
+}
+</style>

--- a/playground/app/pages/[...slug].vue
+++ b/playground/app/pages/[...slug].vue
@@ -1,0 +1,32 @@
+<script lang="ts" setup>
+import { queryContent, useRoute } from '#imports'
+import { useAsyncData } from '#app'
+
+const route = useRoute()
+const { data, error } = await useAsyncData(route.path, () => queryContent(route.path ?? '/').findOne())
+</script>
+
+<template>
+  <main>
+    <article v-if="data">
+      <!-- 'list' transformer content -->
+      <template v-if="data._extension === 'list'">
+        <p>This is a custom "list" transformer:</p>
+        <ul>
+          <li v-for="item in data.body" :key="item">{{ item }}</li>
+        </ul>
+      </template>
+
+      <!-- any other markdown content -->
+      <article v-else>
+        <ContentRenderer :value="data" />
+      </article>
+    </article>
+
+    <!-- 404 not found -->
+    <template v-else-if="error">
+      <p>No content found for "{{ route.path }}"</p>
+      <pre>{{ error.data }}</pre>
+    </template>
+  </main>
+</template>

--- a/playground/content/advanced/gallery.md
+++ b/playground/content/advanced/gallery.md
@@ -20,4 +20,4 @@ recipes:
  
 Here are four delicious recipes:
 
-:content-gallery{:data="recipes"}
+:content-gallery{:items="recipes"}

--- a/playground/content/advanced/query/index.md
+++ b/playground/content/advanced/query/index.md
@@ -2,18 +2,18 @@
 
 > Image with query string 
 
-This image has a query string (won't show in editors, not compatible with Nuxt Image):
+This image has a query string (won't show in editors, **not compatible with Nuxt Image**):
 
-![image](../frontmatter/turkey-casserole.jpg?size=100)
+![image](../../assets/images/sicilian-fish-stew.jpg?test=100)
 
 ```
-../frontmatter/turkey-casserole.jpg?size=100
+../../assets/images/sicilian-fish-stew.jpg?test=100
 ```
 
 This image has no query:
 
-![image](../frontmatter/turkey-casserole.jpg)
+![image](../../assets/images/sicilian-fish-stew.jpg)
 
 ```
-../frontmatter/turkey-casserole.jpg
+../../assets/images/sicilian-fish-stew.jpg
 ```

--- a/playground/content/data/YAML.yml
+++ b/playground/content/data/YAML.yml
@@ -1,3 +1,4 @@
-- one
-- two
-- three
+data
+  - one
+  - two
+  - three

--- a/playground/content/index.md
+++ b/playground/content/index.md
@@ -39,6 +39,11 @@ Data:
 
 - [Data files should not be made public](data/)
 
+Transformers:
+
+- [Custom transformer](transformers/article)
+- [List transformer](transformers/names)
+
 GitHub:
 
 - [Repo and docs](https://github.com/davestewart/nuxt-content-assets)

--- a/playground/content/transformers/article.fire
+++ b/playground/content/transformers/article.fire
@@ -1,0 +1,24 @@
+---
+title: Custom Example
+fire: true
+---
+
+# Hello World
+
+This is a transformer example for files which have a non-standard content extension, e.g. `.fire`.
+
+To support custom file extensions, update `contentExtensions` field in your `nuxt.config.ts`:
+
+```ts
+export default defineNuxtConfig({
+  content: {
+    contentExtensions: 'mdx? csv ya?ml json fire', // add 'fire' extension
+  }
+})
+```
+
+![image](../../assets/images/sicilian-fish-stew.jpg)
+
+```
+![image](../../assets/images/sicilian-fish-stew.jpg)
+```

--- a/playground/content/transformers/names.list
+++ b/playground/content/transformers/names.list
@@ -1,0 +1,6 @@
+dave
+james
+ian
+john
+andy
+bill

--- a/playground/modules/fire/module.ts
+++ b/playground/modules/fire/module.ts
@@ -1,0 +1,18 @@
+import { join } from 'path'
+import { defineNuxtModule } from '@nuxt/kit'
+import type { Nuxt } from '@nuxt/schema'
+
+console.log('custom module imported')
+
+// @see https://github.com/davestewart/nuxt-content-assets/issues/81
+export default defineNuxtModule({
+  setup (_options: any, nuxt: Nuxt) {
+    nuxt.options.nitro.externals = nuxt.options.nitro.externals || {}
+    nuxt.options.nitro.externals.inline = nuxt.options.nitro.externals.inline || []
+    nuxt.options.nitro.externals.inline.push(join(__dirname, 'module'))
+    nuxt.hook('content:context', (contentContext) => {
+      contentContext.transformers.push(join(__dirname, 'transformer.ts'))
+      console.log('custom module hook')
+    })
+  },
+})

--- a/playground/modules/fire/transformer.ts
+++ b/playground/modules/fire/transformer.ts
@@ -1,0 +1,32 @@
+import { defineTransformer } from '@nuxt/content/transformers/utils'
+import { createMarkdownParser } from '@nuxtjs/mdc/runtime'
+import { walk } from '../../../src/runtime/utils'
+
+let parser: ReturnType<typeof createMarkdownParser>
+
+console.log('custom transformer imported')
+
+export default defineTransformer({
+  name: 'custom-transformer',
+  extensions: ['.fire'],
+  async parse (_id, rawContent) {
+    console.log('Parsing custom content', _id)
+
+    if (!parser) {
+      parser = await createMarkdownParser()
+    }
+
+    const file = await parser(rawContent)
+    walk(file.body, (value, parent, key) => {
+      if (parent.type === 'text' && key === 'value' && typeof value === 'string') {
+        parent[key] = '🔥 ' + value
+      }
+    })
+
+    return {
+      _id,
+      ...file.data,
+      body: file.body,
+    }
+  },
+})

--- a/playground/modules/list/module.ts
+++ b/playground/modules/list/module.ts
@@ -1,0 +1,19 @@
+import { join } from 'path'
+import { defineNuxtModule } from '@nuxt/kit'
+import type { Nuxt } from '@nuxt/schema'
+
+console.log('list module imported')
+
+export default defineNuxtModule({
+  setup (_options: any, nuxt: Nuxt) {
+    nuxt.options.nitro.externals = nuxt.options.nitro.externals || {}
+    nuxt.options.nitro.externals.inline = nuxt.options.nitro.externals.inline || []
+    nuxt.options.nitro.externals.inline.push(join(__dirname, 'module.ts'))
+    // console.log(nuxt.options.nitro.externals.inline)
+    nuxt.hook('content:context', (contentContext) => {
+      contentContext.transformers.push(join(__dirname, 'transformer.ts'))
+      console.log('list module hook')
+    })
+  }
+})
+

--- a/playground/modules/list/transformer.ts
+++ b/playground/modules/list/transformer.ts
@@ -1,0 +1,21 @@
+import { defineTransformer } from '@nuxt/content/transformers'
+
+console.log('list transformer imported')
+
+// @see https://v2.content.nuxt.com/recipes/transformers
+export default defineTransformer({
+  name: 'list-transformer',
+  extensions: ['.list'],
+  // @ts-expect-error invalid return type
+  parse (_id: string, rawContent: string) {
+    console.log('Parsing list content', _id)
+    return {
+      _id,
+      body: rawContent
+        .trim()
+        .split('\n')
+        .map(line => line.trim())
+        .sort()
+    }
+  }
+})

--- a/playground/nuxt.config.ts
+++ b/playground/nuxt.config.ts
@@ -1,5 +1,7 @@
 import { defineNuxtConfig } from 'nuxt/config'
 import type { MountOptions } from '@nuxt/content'
+import FireModule from './modules/fire/module'
+import ListModule from './modules/list/module'
 
 // @ts-ignore
 const isStackblitz = process.env.GIT_PROXY?.includes('stackblitz')
@@ -9,7 +11,7 @@ const external = {
   driver: 'github',
   repo: 'davestewart/nuxt-content-assets',
   dir: '/playground/external',
-  prefix: '/external'
+  prefix: '/external',
 }
 
 // no external playground in stackblitz (due to CORS)
@@ -31,12 +33,14 @@ export default defineNuxtConfig({
         { rel: 'preconnect', href: 'https://fonts.googleapis.com' },
         { rel: 'preconnect', href: 'https://fonts.gstatic.com' },
         { rel: 'stylesheet', href: 'https://fonts.googleapis.com/css2?family=Dosis:wght@600;700&display=swap' },
-      ]
+      ],
     },
   },
 
   // @ts-ignore
   modules: [
+    ListModule,
+    FireModule,
     '../src/module',
     '@nuxt/content',
     '@nuxt/image',
@@ -48,7 +52,7 @@ export default defineNuxtConfig({
     sources,
     highlight: {
       theme: 'github-light',
-      preload: ['js']
+      preload: ['js'],
     },
     markdown: {
       anchorLinks: false,
@@ -60,6 +64,9 @@ export default defineNuxtConfig({
     // add image size hints (except for src, as to not interfere with Nuxt Image)
     imageSize: 'style attrs',
 
+    // allow custom transformers
+    contentExtensions: 'mdx? csv ya?ml json fire list',
+
     // show debug messages
     debug: true,
   },
@@ -70,5 +77,5 @@ export default defineNuxtConfig({
     'node_modules/nuxt-content-assets/cache',
   ],
 
-  compatibilityDate: '2024-08-11'
+  compatibilityDate: '2024-08-11',
 })


### PR DESCRIPTION
Closes #81 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified Nuxt Image setup guidance and content extensions configuration for custom transformers.

* **New Features**
  * Added support for custom content file extensions (.fire, .list) via custom transformers.
  * Introduced new example content demonstrating transformer functionality.

* **Updates**
  * Gallery component prop renamed from `data` to `items`.
  * Enhanced content routing with dynamic page handling.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->