### PR TITLE
Update build to export types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### v1.8.3
+
+- Update build to export types [#103](../../issues/103)
+
 ### v1.8.2
 
 - Fix AST props check leading to skipping of asset processing [#102](../../issues/102)

--- a/build.config.ts
+++ b/build.config.ts
@@ -1,0 +1,7 @@
+import { defineBuildConfig } from 'unbuild'
+
+export default defineBuildConfig([
+  {
+    declaration: 'compatible',
+  },
+])

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "type": "module",
   "exports": {
     ".": {
-      "types": "./dist/types.d.mts",
+      "types": "./dist/module.d.ts",
       "import": "./dist/module.mjs"
     }
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nuxt-content-assets",
-  "version": "1.8.2",
+  "version": "1.8.3",
   "description": "Enable locally-located assets in Nuxt Content",
   "repository": {
     "type": "git",

--- a/playground/app/pages/[...slug].vue
+++ b/playground/app/pages/[...slug].vue
@@ -13,7 +13,9 @@ const { data, error } = await useAsyncData(route.path, () => queryContent(route.
       <template v-if="data._extension === 'list'">
         <p>This is a custom "list" transformer:</p>
         <ul>
-          <li v-for="item in data.body" :key="item">{{ item }}</li>
+          <li v-for="item in data.body" :key="item">
+            {{ item }}
+          </li>
         </ul>
       </template>
 

--- a/src/module.ts
+++ b/src/module.ts
@@ -10,6 +10,15 @@ import type { ModuleMeta, Nuxt, NuxtConfigLayer } from '@nuxt/schema'
 import type { MountOptions } from '@nuxt/content'
 import type { ImageSize, ModuleOptions } from './types'
 
+// Re-export types for consumers
+export type {
+  ModuleOptions,
+  ImageSize,
+  AssetConfig,
+  AssetMessage,
+  SocketInstance
+} from './types'
+
 const resolve = createResolver(import.meta.url).resolve
 
 const meta: ModuleMeta = {


### PR DESCRIPTION
The following changes were made:

- added build config so [unjs/unbuild](https://github.com/unjs/unbuild#configuration) creates compatible typescript declaration files
- re-exported types from `src/module.ts` so they are exported in the build

Closes #103

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added publicly exported type definitions for configuration and assets.

* **Chores**
  * Version bumped to v1.8.3.
  * Updated type export path in package configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->